### PR TITLE
docs: fix links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ $ pip install -r requirements.txt
 $ python main.py
 ```
 
-Once your server is up and running, you can authenticate your vehicle. In our current set up, we are using Smartcar's [test mode](https://smartcar.com), so you can log in with any username and password. To authenticate, navigate to `http://localhost:8000/login`. Once you have authenticated, go to `http://localhost:8000/vehicle` to see your vehicle information.
+Once your server is up and running, you can authenticate your vehicle. In our current set up, we are using Smartcar's [test mode](https://smartcar.com/docs/guides/testing/), so you can log in with any username and password. To authenticate, navigate to `http://localhost:8000/login`. Once you have authenticated, go to `http://localhost:8000/vehicle` to see your vehicle information.
 
 **Note:** We recommend you use a virtual environment. If you are using Python 3, refer to [this guide](https://docs.python.org/3/tutorial/venv.html). If you are using Python 2, refer to the [docs](https://virtualenv.pypa.io).
 
 ## Next Steps
-Read our [API Docs](https://smartcar.com/docs) to learn what else you can do with Smartcar's API.
+Read our [API Docs](https://smartcar.com/docs/api) to learn what else you can do with Smartcar's API.
 
 Learn more about the [Python SDK](https://github.com/smartcar/python-sdk) and how it can be used.


### PR DESCRIPTION
```
[I] ➜ markdown-link-check README.md

FILE: README.md
[✓] https://smartcar.com
[✓] https://docs.python.org/3/tutorial/venv.html
[✓] https://virtualenv.pypa.io
[✓] https://smartcar.com/docs
[✓] https://github.com/smartcar/python-sdk
```