### PR TITLE
chore: update `tutorial` dependencies to match `app`

### DIFF
--- a/tutorial/requirements.txt
+++ b/tutorial/requirements.txt
@@ -1,4 +1,4 @@
 Flask==1.0.2
 flask-cors==3.0.7
-requests==2.19.1
-smartcar==1.0.10
+requests==2.20.1
+smartcar==3.0.0


### PR DESCRIPTION
Addressees: [CVE-2018-18074](https://nvd.nist.gov/vuln/detail/CVE-2018-18074)
