### PR TITLE
Pin werkzeug to 2.3.8 in requirements.txt

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -2,3 +2,4 @@ Flask==2.0.1
 Flask-Cors==3.0.10
 requests==2.25.1
 smartcar==6.3.0
+werkzeug==2.3.8

--- a/tutorial/requirements.txt
+++ b/tutorial/requirements.txt
@@ -2,3 +2,4 @@ Flask==2.0.1
 Flask-Cors==3.0.10
 requests==2.25.1
 smartcar==6.3.0
+werkzeug==2.3.8


### PR DESCRIPTION
The `werkzeug` library recently released version 3.0.0, which it seems is not compatible with the version of `flask` we are using. To fix this I have added a line to requirements.txt to pin `werkzeug` to 2.3.8, which was the last release before the major version bump.

This should resolve the following error:
```
ImportError: cannot import name 'url_quote' from 'werkzeug.urls'
```